### PR TITLE
Account confirmation, Login saving, Styling and Routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 /tmp
 .DS_Store
 *~
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 # Use ActiveModel has_secure_password
 gem 'bcrypt', '~> 3.1.7'
 
+# Use Figaro for configuration security and credential management
+gem 'figaro'
+
 # Use Unicorn as the app server
 # gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,8 @@ GEM
     debug_inspector (0.0.2)
     erubis (2.7.0)
     execjs (2.6.0)
+    figaro (1.1.1)
+      thor (~> 0.14)
     fuzzy_match (2.1.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
@@ -155,6 +157,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   coffee-rails (~> 4.1.0)
+  figaro
   fuzzy_match
   hirb
   jbuilder (~> 2.0)

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -48,6 +48,11 @@ body {
     color: orange;
 }
 
+.flash-header {
+  padding-top: 80px;
+  padding-bottom: 10px;
+}
+
 h1.ui.center.aligned.header.padding-top {
     padding-top: 3em;
 }

--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -1,3 +1,13 @@
 .admin-page {
   padding-bottom: 30px;
 }
+
+.aligned-text {
+  padding-left: 10px;
+  font-family: "Source Sans Pro","Helvetica Neue",Helvetica,Arial,sans-serif;
+  font-size: 125%;
+}
+
+.centered {
+  text-align: center;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,16 +3,47 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
   include SessionsHelper
-  before_filter :current_user, :permission_check, :check_if_logged_on
+  before_filter :current_user, :permission_check, :check_if_redirect
 
-  # addresses that can be accessed while not logged in, but should not be accessed once logged in
+  # addresses that can ONLY be accessed while logged out
   def outside_path?(param)
     outside_addresses = [
       "/login",
       "/signup",
-      "/"
+      "/" # equivalent to /login
     ]
-    outside_addresses.any?{ |path| path[param] }
+    outside_addresses.any?{ |path| path == param }
+  end
+
+  # check if action is permitted when not logged in
+  def unauthenticated_action?(controller, action)
+    controller == "users" && action == "create"
+  end
+
+  # addresses that can be accessed while account requires confirming
+  def confirm_path?(param)
+    confirm_addresses = [
+      "/confirm"
+    ]
+    confirm_addresses.any?{ |path| path == param }
+  end
+
+  # check if one of the confirm post actions is called
+  def confirm_post_action?(controller, action)
+    controller == "users" && action == "send_confirmation_email"
+  end
+
+  # check if one of the confirm email actions is called
+  def confirm_email_action?(controller, action)
+    controller == "users" && action == "confirm_account"
+  end
+
+  # addresses that should never be redirected
+  def full_access_path?(param)
+    full_access_addresses = [
+      "/logout"
+    ]
+    full_access_addresses.any?{ |path| path == param }
   end
 
   def current_user
@@ -23,17 +54,37 @@ class ApplicationController < ActionController::Base
     @permission = @current_user!=nil ? @current_user.permission_level : 0
   end
 
-  # Check if logged in, and if not, then redirect
-  def check_if_logged_on
-    # get the current path and verify that the users are logged in, or trying to login/signup
+  # check if the user's account is confirmed
+  def account_confirmed?
+    current_user.confirmation_token && current_user.confirmation_expiry.nil?
+  end
+
+  # Check if redirecting the user is required
+  def check_if_redirect
+    # get the current controller and action for the path
     controller = controller_name
     action = action_name
-		
-    # if logged in, send the user to their home page if trying to access the login or signup pages
-    if outside_path?(request.path) || (controller == "users" && action == "create") 
-      redirect_to @current_user if !current_user.nil?
-    elsif !outside_path?(request.path) && !(controller == "users" && action == "create")
-      redirect_to :login if current_user.nil?
+
+    # handle user pathing
+    if !full_access_path?(request.path)
+      # trying to access path outside of the authenticated zone
+      if outside_path?(request.path) || unauthenticated_action?(controller, action)
+        redirect_to @current_user if logged_in?
+      # trying to access confirmation pages
+      elsif confirm_path?(request.path) || confirm_post_action?(controller, action)
+        if !logged_in?
+          redirect_to :login
+        elsif account_confirmed?
+          redirect_to @current_user
+        end
+      # trying to access any other page
+      else
+        if !logged_in?
+          redirect_to :login
+        elsif !confirm_email_action?(controller, action) && !account_confirmed?
+          redirect_to :confirm
+        end
+      end
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,11 +54,6 @@ class ApplicationController < ActionController::Base
     @permission = @current_user!=nil ? @current_user.permission_level : 0
   end
 
-  # check if the user's account is confirmed
-  def account_confirmed?
-    current_user.confirmation_token && current_user.confirmation_expiry.nil?
-  end
-
   # Check if redirecting the user is required
   def check_if_redirect
     # get the current controller and action for the path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,16 +1,15 @@
 class SessionsController < ApplicationController
-	def new
+  def new
   end
 
   def create
     user = User.find_by(username: params[:session][:username])
     #try to login
     if user && user.authenticate(params[:session][:password])
-      #LogIn
+      # login
       flash.now[:notice] = 'Logged in Successfully!'
       login user
-			params[:session][:remember_me] == '1' ? remember(user) : forget(user)
-			logger.info 'User info passed: #{user}'
+      params[:session][:remember_me] == '1' ? remember(user) : forget(user)
       redirect_to user #goes to user's profile
     else
       flash.now[:danger] = 'Incorrect username/password combination.'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+
+  def flash_style(flash_level)
+    case flash_level
+      when "success" then "ui success message"
+      when "error" then "ui negative message"
+      when "danger" then "ui negative message"
+      when "notice" then "ui info message"
+      when "warning" then "ui warning message"
+    end
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -42,4 +42,9 @@ module SessionsHelper
     @current_user = nil
   end
 
+  # check if the user's account is confirmed
+  def account_confirmed?
+    current_user && current_user.confirmation_token && current_user.confirmation_expiry.nil?
+  end
+
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -20,17 +20,17 @@ module SessionsHelper
     current_user.permission_level > 2
   end
 
-	def remember(user)
-		user.remember
-		cookies.permanent.signed[:session_key] = user.id
-		cookies.permanent[:session_remember] = user.remember_token
-	end
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:session_key] = user.id
+    cookies.permanent[:session_remember] = user.remember_token
+  end
 
-	def forget(user)
-		user.forget
-		cookies.delete(:session_key)
-		cookies.delete(:session_remember)
-	end
+  def forget(user)
+    user.forget
+    cookies.delete(:session_key)
+    cookies.delete(:session_remember)
+  end
 
   def logged_in?
     !current_user.nil?

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,5 +1,5 @@
 class UserMailer < ActionMailer::Base
-  default :from => "ian.m.y.wong@gmail.com"
+  default :from => "teamup.confirmation@gmail.com"
 
   def register_account(user)
     @user = user

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,9 @@
+class UserMailer < ActionMailer::Base
+  default :from => "ian.m.y.wong@gmail.com"
+
+  def register_account(user)
+    @user = user
+    email_target = %("#{@user.username}" <#{@user.email}>)
+    mail(to: email_target, subject: "TeamUp - Confirm Your Account")
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+require 'date'
 class User < ActiveRecord::Base
   has_many :user_proficiencies
   has_many :user_teams
@@ -24,18 +25,34 @@ class User < ActiveRecord::Base
     SecureRandom.urlsafe_base64
   end
 
-	def authenticated?(remember_token)
-		return false if remember_digest.nil?
-		BCrypt::Password.new(remember_digest).is_password?(remember_token)
-	end
+  def authenticated?(remember_token)
+    return false if remember_digest.nil?
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
 
   def remember
-		self.remember_token = User.new_remember_token
+    self.remember_token = User.new_remember_token
     update_attribute(:remember_digest, BCrypt::Password.create(remember_token))
-	end
+  end
 
-	def forget
-		update_attribute(:remember_digest, nil)
-	end
+  def forget
+    update_attribute(:remember_digest, nil)
+  end
+
+  def confirmation_action
+    if !self.confirmation_token
+      safe_token = SecureRandom.urlsafe_base64
+      update_attribute(:confirmation_token, safe_token)
+      update_attribute(:confirmation_expiry, DateTime.now + 3)
+      safe_token
+    else
+      update_attribute(:confirmation_expiry, DateTime.now + 3)
+      self.confirmation_token
+    end
+  end
+
+  def activate_account
+    update_attribute(:confirmation_expiry, nil)
+  end
 
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,14 @@
 
 <body id="teamUp" class="index popup">
 <%= render "pages/header" %>
+<div class="flash-header">
+  <% flash.each do |message_type, message| %>
+    <div class="<%= flash_style(message_type) %>">
+      <i class="close icon"></i>
+      <%= message %>
+    </div>
+  <% end %>
+</div>
 <%= yield %>
 
 </body>

--- a/app/views/pages/_header.html.erb
+++ b/app/views/pages/_header.html.erb
@@ -8,6 +8,7 @@
       </div>
       <div class="right menu">
         <% if logged_in? %>
+          <% if account_confirmed? %>
           <div class="ui category search item">
             <div class="ui transparent black icon input">
               <input class="prompt" type="text" placeholder="Search...">
@@ -42,6 +43,15 @@
               <%= link_to "Log out", logout_path, method: "delete", class: 'item' %>
             </div>
           </div>
+          <% else  %>
+          <div class="ui dropdown item">
+            <%= current_user.username %>
+            <i class="dropdown icon"></i>
+            <div class="menu">
+              <%= link_to "Log out", logout_path, method: "delete", class: 'item' %>
+            </div>
+          </div>
+          <% end %>
 
         <% else %>
           <div class="item">

--- a/app/views/pages/admin.html.erb
+++ b/app/views/pages/admin.html.erb
@@ -1,11 +1,7 @@
 <div class="admin-page">
   <h1 class="ui center aligned header padding-top">Admin Panel for <%= @current_user.username %></h1>
   <div class="ui container">
-    <% if flash[:notice] %>
-      <div id="notice">
-        <%= notice %>
-      </div>
-    <% end %>
+
     <p id="notice"><%= notice %></p>
 
     <% if @permission >= 5 %>

--- a/app/views/pages/confirm.html.erb
+++ b/app/views/pages/confirm.html.erb
@@ -1,0 +1,10 @@
+<div class="ui container aligned-text">
+In order to take advantage of the wonderful workings of TeamUp, it's important that we know that you're as committed to this process as we are. By confirming your email, you agree to sign away all doubts and worries to us, and let our super-duper algorithms do all the worrying for you.
+  <br/>
+  <br/>
+  <div class="centered">
+    <%= button_to [:confirm_account, @current_user], class: "ui positive button", data: { disable_with: "Email Sent!" } do %>
+      TeamUp Now, <%= @current_user.username %>!
+    <% end %>
+  </div>
+</div>

--- a/app/views/sessions/_login.html.erb
+++ b/app/views/sessions/_login.html.erb
@@ -1,11 +1,6 @@
 <%= form_for(:session, url: login_path, :html => {:class => 'ui form'}) do |f| %>
 
-  <% flash.each do |message_type, message| %>
-    <div class="ui negative message">
-      <i class="close icon"></i>
-      <%= message %>
-    </div>
-  <% end %>
+  <p id="notice"><%= notice %></p>
 
   <div class="ui stacked segment">
     <div class="field">
@@ -19,10 +14,8 @@
     </div>
 
     <div class="ui checkbox">
-      <%= f.label :remember_me, class: "checkbox inline" do %>
-        <%= f.check_box :remember_me %>
-        <span>Remember me on this computer</span>
-      <% end %>
+      <%= f.check_box :remember_me %>
+      <%= f.label :remember_me %>
     </div>
 
     <div class="actions right-align">

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<h1 class="ui center aligned header padding-top">Login</h1>
+<h1 class="ui center aligned header">Login</h1>
 <div class="ui text container">
     <%= render "sessions/login" || 'Login Page Error' %>
   <div class="ui segment center aligned">

--- a/app/views/user_mailer/register_account.html.erb
+++ b/app/views/user_mailer/register_account.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <div>
+Welcome to TeamUp, <%= @user.username %>!
+
+In order to activate your account and all the other schtuff we provide, we need you to click the link below to verify your account.
+
+If you would rather not TeamUp, feel free to ignore this!
+
+<%= confirm_account_user_url(@user.confirmation_action) %>
+    </div>
+  </body>
+</html>

--- a/app/views/user_mailer/register_account.text.erb
+++ b/app/views/user_mailer/register_account.text.erb
@@ -1,0 +1,7 @@
+Welcome to TeamUp, <%= @user.username %>!
+
+In order to activate your account and all the other schtuff we provide, we need you to click the link below to verify your account.
+
+If you would rather not TeamUp, feel free to ignore this!
+
+<%= confirm_account_user_url(@user.confirmation_action) %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -14,7 +14,21 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  #config.action_mailer.raise_delivery_errors = false
+  # Mailer default settings
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.default_url_options = {
+    :host => "localhost:3000"
+  }
+  # SMTP settings for gmail
+  config.action_mailer.smtp_settings = {
+    :address              => "smtp.gmail.com",
+    :port                 => 587,
+    :user_name            => ENV['gmail_username'],
+    :password             => ENV['gmail_password'],
+    :authentication       => "plain",
+    :enable_starttls_auto => true
+  }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,11 @@ Rails.application.routes.draw do
   resources :games_users, only: [:create, :destroy]
   resources :user_proficiencies, only: [:create, :destroy]
   resources :teams
-  resources :users, except: :new
+  resources :users, except: :new do
+    member do
+      get :confirm_account
+    end
+  end
   resources :user_teams
   resources :proficiency_posts, only: :create
   resources :games, only: [:create, :show, :destroy] do
@@ -15,6 +19,7 @@ Rails.application.routes.draw do
   root 'sessions#new'
 
   get    'profile' => 'users#show'
+  get    'confirm' => 'pages#confirm'
   get    'signup'  => 'users#new'
   get    'login'   => 'sessions#new'
   post   'login'   => 'sessions#create'
@@ -22,6 +27,7 @@ Rails.application.routes.draw do
 
   post 'teams/:id/requestDecision' => 'teams#requestDecision', as: :request_decision
   post 'users/:id/endorse/:proficiency_id' => 'users#endorse', as: :endorse
+  post   'users/:id/confirm_account' => 'users#send_confirmation_email', as: :confirm_account
 
   get    'admin'   => 'pages#admin'
   post   'admin'   => 'pages#create'


### PR DESCRIPTION
=> account confirmation, remember_me checkbox, styling and redirecting/authentication handling

Users must now confirm their accounts through email (see Issue #61), which forced the redirecting/routing performed in the ApplicationController to be revised. Styling of the header and flash messages have been corrected (the <p> notices should be addressed similarly in the future, see Issue #63), and the remember_me checkbox from Issue #58 is fixed now.
